### PR TITLE
Add Dynamic Source Table Variables to DBT Project Configuration and Models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -9,6 +9,15 @@ config-version: 2
 # This setting configures which "profile" dbt uses for this project.
 profile: 'coherent_dbts'
 
+# default variable names if no vars are passed into the dbt run command
+vars:
+  raw_database: "ethereum_raw_data"
+  source_table_transactions: "transactions"
+  source_table_traces: "traces"
+  source_table_blocks: "blocks"
+  source_table_logs: "logs"
+  contracts_database: "evm_contract_fragments_data"
+
 # These configurations specify where dbt should look for different types of files.
 # The `model-paths` config, for example, states that models in this project can be
 # found in the "models/" directory. You probably won't need to change these!

--- a/models/blocks/decoded_blocks.sql
+++ b/models/blocks/decoded_blocks.sql
@@ -22,7 +22,7 @@
         TRANSACTIONS_ROOT,
         UNCLES,
         TRY_CAST(hex_to_int(BASE_FEE_PER_GAS) as FLOAT) AS base_fee_per_gas
-    FROM {{ source('ethereum_raw_data', 'blocks') }}
+    FROM {{ source(var('raw_database'), 'blocks') }}
     WHERE to_number(SUBSTR(block_number, 3), repeat('X', length(SUBSTR(block_number, 3)))) > (SELECT MAX(CAST(block_number AS INTEGER)) FROM {{ this }}) -- this is the only change
 {% else %}
     SELECT
@@ -46,5 +46,5 @@
         TRANSACTIONS_ROOT,
         UNCLES,
         TRY_CAST(hex_to_int(BASE_FEE_PER_GAS) as FLOAT) AS base_fee_per_gas
-    FROM {{ source('ethereum_raw_data', 'blocks') }}
+    FROM {{ source(var('raw_database'), 'blocks') }}
 {% endif %}

--- a/models/logs/decoded_logs.sql
+++ b/models/logs/decoded_logs.sql
@@ -12,7 +12,7 @@
             TRANSACTION_HASH,
             TRY_CAST(hex_to_int(TRANSACTION_INDEX) as FLOAT) as TRANSACTION_INDEX,
             REMOVED
-        FROM {{ source('ethereum_raw_data', 'logs') }}
+        FROM {{ source(var('raw_database'), 'logs') }}
         WHERE to_number(SUBSTR(block_number, 3), repeat('X', length(SUBSTR(block_number, 3))))  > (SELECT MAX(CAST(block_number AS INTEGER)) FROM {{ this }}) -- this is the only change
     ),
 {% else %}
@@ -27,7 +27,7 @@
             TRANSACTION_HASH,
             TRY_CAST(hex_to_int(TRANSACTION_INDEX) as FLOAT) as TRANSACTION_INDEX,
             REMOVED
-        FROM {{ source('ethereum_raw_data', 'logs') }}
+        FROM {{ source(var('raw_database'), 'logs') }}
     ),
 {% endif %}
 
@@ -53,7 +53,7 @@ merged AS (
         e.abi,
         e.hashable_signature
     FROM logs_with_event_id l
-    LEFT JOIN {{ source('evm_contract_fragments_data', 'event_fragments') }} e
+    LEFT JOIN {{ source(var('contracts_database'), 'event_fragments') }} e
         ON l.extracted_event_id = e.event_id
 ),
 

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -1,22 +1,26 @@
 version: 2
 
 sources:
-  - name: ethereum_raw_data
+  - name: "{{ var('raw_database') }}"
     description: "Database of ethereum raw"
-    database: ethereum_raw_data
+    database: "{{ var('raw_database') }}"
     schema: raw
     tables:
       - name: transactions
         description: "ethereum raw transactions"
+        identifier: "{{ var('source_table_transactions') }}"
       - name: logs
         description: "ethereum raw logs"
+        identifier: "{{ var('source_table_logs') }}"
       - name: traces
         description: "ethereum raw traces"
+        identifier: "{{ var('source_table_traces') }}"
       - name: blocks
         description: "ethereum raw blocks"
-  - name: evm_contract_fragments_data
+        identifier: "{{ var('source_table_blocks') }}"
+  - name: "{{ var('contracts_database') }}"
     description: "Database of ethereum contract info, including event fragments and method fragments"
-    database: evm_contract_fragments_data
+    database: "{{ var('contracts_database') }}"
     schema: evm
     tables:
       - name: method_fragments

--- a/models/traces/decoded_traces.sql
+++ b/models/traces/decoded_traces.sql
@@ -20,7 +20,7 @@
             TYPE,
             TRY_CAST(hex_to_int(VALUE) as FLOAT) as VALUE,
             SUBSTRING(INPUT, 0, 10) AS METHOD_HEADER
-        FROM {{ source('ethereum_raw_data', 'traces') }}
+        FROM {{ source(var('raw_database'), 'traces') }}
         WHERE to_number(SUBSTR(block_number, 3), repeat('X', length(SUBSTR(block_number, 3))))  > (SELECT MAX(CAST(block_number AS INTEGER)) FROM {{ this }}) -- this is the only change
     ),
 {% else %}
@@ -43,7 +43,7 @@
             TYPE,
             TRY_CAST(hex_to_int(VALUE) as FLOAT) as VALUE,
             SUBSTRING(INPUT, 0, 10) AS METHOD_HEADER
-        FROM {{ source('ethereum_raw_data', 'traces') }}
+        FROM {{ source(var('raw_database'), 'traces') }}
     ),
 {% endif %}
 
@@ -54,7 +54,7 @@ merged AS (
         m.hashable_signature,
         m.abi
     FROM traces t
-    LEFT JOIN {{ source('evm_contract_fragments_data', 'method_fragments') }} m
+    LEFT JOIN {{ source(var('contracts_database'), 'method_fragments') }} m
         ON t.METHOD_HEADER = m.METHOD_ID
 ),
 

--- a/models/transactions/decoded_transactions.sql
+++ b/models/transactions/decoded_transactions.sql
@@ -27,7 +27,7 @@
             ACCESS_LIST,
             INPUT,
             SUBSTRING(INPUT, 0, 10) AS METHOD_HEADER
-        FROM {{ source('ethereum_raw_data', 'transactions') }}
+        FROM {{ source(var('raw_database'), 'transactions') }}
         WHERE to_number(SUBSTR(block_number, 3), repeat('X', length(SUBSTR(block_number, 3))))  > (SELECT MAX(CAST(block_number AS INTEGER)) FROM {{ this }}) -- this is the only change
     ),
 {% else %}
@@ -57,7 +57,7 @@
             ACCESS_LIST,
             INPUT,
             SUBSTRING(INPUT, 0, 10) AS METHOD_HEADER
-        FROM {{ source('ethereum_raw_data', 'transactions') }}
+        FROM {{ source(var('raw_database'), 'transactions') }}
     ),
 {% endif %}
 
@@ -71,7 +71,7 @@ merged AS (
             ELSE NULL
         END AS ABI
     FROM input_and_transaction t
-    LEFT JOIN {{ source('evm_contract_fragments_data', 'method_fragments') }} m
+    LEFT JOIN {{ source(var('contracts_database'), 'method_fragments') }} m
         ON t.METHOD_HEADER = m.METHOD_ID
 ),
 


### PR DESCRIPTION
This PR introduces the usage of variables in the dbt_project.yml configuration file and in the schema and models to allow for more flexibility in specifying source tables during runtime. By implementing this change, we enable the DBT project to handle different source tables without modifying the model files, which simplifies the maintenance process and streamlines the workflow.

Key Changes:

Added raw_database variable to the dbt_project.yml file, which is used to specify the source schema for the models.

Modified the schema.yml file to use the raw_database variable in the source definitions.

Updated the models to use the raw_database variable when referencing source tables.