### PR TITLE
Add verbs to decoded traces and transactions

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -25,6 +25,9 @@ vars:
   decoded_table_traces: "decoded_traces"
   decoded_table_blocks: "decoded_blocks"
   decoded_table_logs: "decoded_logs"
+  verbs: "enricher"
+  evm: "evm"
+  verbs_table: "verbs"
   backfill: False
 
 

--- a/models/decoded_traces.sql
+++ b/models/decoded_traces.sql
@@ -77,10 +77,14 @@ merged AS (
         t.*,
         m.METHOD_ID,
         m.hashable_signature,
-        m.abi
+        m.abi,
+        v.VERB,
+        v.OBJECT
     FROM traces t
     LEFT JOIN {{ source(var('contracts_database'), 'method_fragments') }} m
         ON t.METHOD_HEADER = m.METHOD_ID
+    LEFT JOIN {{ source(var('verbs'), 'verbs')}} v
+        ON t.METHOD_HEADER = v.METHOD_ID
 ),
 
 decoded_traces AS (
@@ -103,6 +107,8 @@ decoded_traces AS (
         VALUE,
         ABI,
         HASHABLE_SIGNATURE,
+        VERB,
+        OBJECT,
         decode_input(abi, SUBSTRING(INPUT,11))[0] as decoded_result,
         decode_input(abi, SUBSTRING(INPUT,11))[1] as decoded_success
     FROM merged
@@ -128,6 +134,8 @@ decoded_cleaned AS (
         TYPE,
         VALUE,
         HASHABLE_SIGNATURE,
+        VERB,
+        OBJECT,
         CASE
             WHEN decoded_success = True THEN decoded_result
             ELSE NULL
@@ -154,6 +162,8 @@ no_abi AS (
         TYPE,
         VALUE,
         NULL AS HASHABLE_SIGNATURE,
+        NULL AS VERB,
+        NULL AS OBJECT,
         NULL AS DECODED_INPUT
     FROM merged
     WHERE ABI IS NULL

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -44,3 +44,11 @@ sources:
       - name: decoded_blocks
         description: "ethereum decoded blocks"
         identifier: "{{ var('decoded_table_blocks') }}"
+  - name: "{{ var('verbs') }}"
+    description: "Database mapping method IDs to function verb and object"
+    database: "{{ var('verbs') }}"
+    schema: "{{ var('evm') }}"
+    tables:
+      - name: verbs
+        description: "table of method fragments"
+        identifier: "{{ var('verbs_table') }}"


### PR DESCRIPTION
we join our decoded transactions and traces with our ethereum verbs table to get verb/object pairs in our decoded tables